### PR TITLE
Prevent writing beyond array length

### DIFF
--- a/firmware/SparkFun_Speed_Trap/SparkFun_Speed_Trap.ino
+++ b/firmware/SparkFun_Speed_Trap/SparkFun_Speed_Trap.ino
@@ -152,7 +152,7 @@ void loop()
     if(safeDelta)
     {
       deltas[deltaSpot++] = deltaDistance;
-      if (deltaSpot > numberOfDeltas) deltaSpot = 0; //Wrap this variable
+      if (deltaSpot >= numberOfDeltas) deltaSpot = 0; //Wrap this variable
     }
 
     //Get average of the current deltas array


### PR DESCRIPTION
The current code creates a `deltas` array of `8` length, but the `deltaSpot` variable attempts to write at index `8` which causes various corruption.  This changes so that it will only go to index `7`